### PR TITLE
Replace != by all.equal in focal.functions

### DIFF
--- a/R/gridtools.R
+++ b/R/gridtools.R
@@ -1153,7 +1153,7 @@ focal.function = function( in.grid, in.factor.grid, out.grid.prefix,
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            !all.equal(in.hdr$cellsize, in.factor.hdr$cellsize) |
+            isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)) |
             in.hdr$xllcorner != in.factor.hdr$xllcorner |
             in.hdr$yllcorner != in.factor.hdr$yllcorner)
             stop("input grid and factor grid must have same extent and cellsize")
@@ -1522,7 +1522,7 @@ multi.focal.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if (!all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize) |
+            if (isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
                 in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
                 in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
                 stop("incompatible input grids")
@@ -1545,7 +1545,7 @@ multi.focal.function = function(
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            !all.equal(in.hdr$cellsize, in.factor.hdr$cellsize))
+            isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)))
             stop("input grid and factor grid must have same extent and cellsize")
     }
 
@@ -1969,7 +1969,7 @@ multi.local.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if ( !all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize) |
+            if ( isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
                   in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
                   in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
                 stop("incompatible input grids")

--- a/R/gridtools.R
+++ b/R/gridtools.R
@@ -1153,7 +1153,7 @@ focal.function = function( in.grid, in.factor.grid, out.grid.prefix,
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)) |
+            !isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)) |
             in.hdr$xllcorner != in.factor.hdr$xllcorner |
             in.hdr$yllcorner != in.factor.hdr$yllcorner)
             stop("input grid and factor grid must have same extent and cellsize")
@@ -1522,7 +1522,7 @@ multi.focal.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if (isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
+            if (!isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
                 in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
                 in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
                 stop("incompatible input grids")
@@ -1545,7 +1545,7 @@ multi.focal.function = function(
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)))
+            !isTRUE(all.equal(in.hdr$cellsize, in.factor.hdr$cellsize)))
             stop("input grid and factor grid must have same extent and cellsize")
     }
 
@@ -1969,9 +1969,9 @@ multi.local.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if ( isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
-                  in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
-                  in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
+            if (!isTRUE(all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize)) |
+                in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
+                in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows)
                 stop("incompatible input grids")
         }
     }

--- a/R/gridtools.R
+++ b/R/gridtools.R
@@ -1153,7 +1153,7 @@ focal.function = function( in.grid, in.factor.grid, out.grid.prefix,
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            in.hdr$cellsize != in.factor.hdr$cellsize |
+            !all.equal(in.hdr$cellsize, in.factor.hdr$cellsize) |
             in.hdr$xllcorner != in.factor.hdr$xllcorner |
             in.hdr$yllcorner != in.factor.hdr$yllcorner)
             stop("input grid and factor grid must have same extent and cellsize")
@@ -1522,9 +1522,9 @@ multi.focal.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if ( in.hdrs[[k]]$cellsize != in.hdrs[[1]]$cellsize |
-                  in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
-                  in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
+            if (!all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize) |
+                in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
+                in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
                 stop("incompatible input grids")
         }
     }
@@ -1545,7 +1545,7 @@ multi.focal.function = function(
         in.factor.hdr = read.ascii.grid.header(in.factor.file,dec=dec)
         if (in.hdr$ncols != in.factor.hdr$ncols |
             in.hdr$nrows != in.factor.hdr$nrows |
-            in.hdr$cellsize != in.factor.hdr$cellsize )
+            !all.equal(in.hdr$cellsize, in.factor.hdr$cellsize))
             stop("input grid and factor grid must have same extent and cellsize")
     }
 
@@ -1969,7 +1969,7 @@ multi.local.function = function(
         in.hdrs[[k]] = read.ascii.grid.header(in.files[[k]],dec=dec)
         nodata.vals[[k]] = unique(c(nodata.values,in.hdrs[[k]]$nodata_value))
         if (k > 1) {
-            if ( in.hdrs[[k]]$cellsize != in.hdrs[[1]]$cellsize |
+            if ( !all.equal(in.hdrs[[k]]$cellsize, in.hdrs[[1]]$cellsize) |
                   in.hdrs[[k]]$ncols != in.hdrs[[1]]$ncols |
                   in.hdrs[[k]]$nrows != in.hdrs[[1]]$nrows )
                 stop("incompatible input grids")


### PR DESCRIPTION
Hi Donovan,

I had a few problems with the multi.local.function. It told me I had incompatible input grids due to different cell sizes. However, the cellsize differences were tiny, something like 30 vs. 30.000000001. Therefore, I changed various if-statements by using all.equal instead of !=. I hope that's ok with you.

All the best,

Jannes
